### PR TITLE
Add target to the Makefile for making a "portable" zip.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ prefix_install: installables
 	install_name_tool -rpath "/Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks" "@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks" "$(PREFIX)/bin/swiftlint"
 	install_name_tool -rpath "/Library/Frameworks" "@executable_path/../Frameworks" "$(PREFIX)/bin/swiftlint"
 
+portable_zip: installables
+	cp -Rf "$(TEMPORARY_FOLDER)$(FRAMEWORKS_FOLDER)/SwiftLintFramework.framework" "$(TEMPORARY_FOLDER)"
+	cp -f "$(TEMPORARY_FOLDER)$(BINARIES_FOLDER)/swiftlint" "$(TEMPORARY_FOLDER)"
+	install_name_tool -rpath "/Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks" "@executable_path/SwiftLintFramework.framework/Versions/Current/Frameworks" "$(TEMPORARY_FOLDER)/swiftlint"
+	install_name_tool -rpath "/Library/Frameworks" "@executable_path" "$(TEMPORARY_FOLDER)/swiftlint"
+	rm -f "./portable_swiftlint.zip"
+	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "swiftlint" "SwiftLintFramework.framework") > "./portable_swiftlint.zip"
+
 package: installables
 	pkgbuild \
 		--component-plist "$(COMPONENTS_PLIST)" \


### PR DESCRIPTION
The zip contains the executable and the framework, with the executable modified to look for the framework in the same directory as the executable.

This is my alternate solution given the response to https://github.com/realm/SwiftLint/pull/650.

@vokal/ios-developers Review please?
